### PR TITLE
Adjust method signatures to match parent

### DIFF
--- a/action.php
+++ b/action.php
@@ -14,7 +14,7 @@ require_once(DOKU_PLUGIN.'action.php');
 
 class action_plugin_caption extends DokuWiki_Action_Plugin {
 
-    public function register(&$controller) {
+    public function register(Doku_Event_Handler $controller) {
         $controller->register_hook("TOOLBAR_DEFINE", "AFTER", $this, "insert_button", array ());
     }
 

--- a/syntax/caption.php
+++ b/syntax/caption.php
@@ -70,7 +70,7 @@ class syntax_plugin_caption_caption extends DokuWiki_Syntax_Plugin {
         $this->Lexer->addExitPattern('</table>','plugin_caption_caption');
     }
 
-    public function handle($match, $state, $pos, &$handler){
+    public function handle($match, $state, $pos, Doku_Handler $handler){
         switch ($state) {
           case DOKU_LEXER_ENTER :
             $match = substr($match,1,-1);
@@ -84,7 +84,7 @@ class syntax_plugin_caption_caption extends DokuWiki_Syntax_Plugin {
         return array();
     }
 
-    public function render($mode, &$renderer, $data) {
+    public function render($mode, Doku_Renderer $renderer, $data) {
         if ($mode == 'xhtml') {
 
             list($state,$match) = $data;

--- a/syntax/reference.php
+++ b/syntax/reference.php
@@ -56,14 +56,14 @@ class syntax_plugin_caption_reference extends DokuWiki_Syntax_Plugin {
         $this->Lexer->addSpecialPattern('{{ref>.+?}}',$mode,'plugin_caption_reference');
     }
 
-    public function handle($match, $state, $pos, &$handler){
+    public function handle($match, $state, $pos, Doku_Handler $handler){
         if (!(strpos($match,'{{ref>')===false)) {
               return array($state, substr($match,6,-2));
         }
         return array();
     }
 
-    public function render($mode, &$renderer, $data) {
+    public function render($mode, Doku_Renderer $renderer, $data) {
         if ($mode == 'xhtml') {
 
             list($state,$match) = $data;


### PR DESCRIPTION
Starting with PHP 7, classes that overide methods from their parent have to match their parent's method signature regarding type hints. Otherwise PHP will throw an error.

Your plugin seems not to match DokuWiki's method signatures causing it to fail under PHP7. This patch tries to fix that.

Please note that this patch and the resulting pull request were created using an automated tool. Something might have gone, wrong so please carefully check before merging.

If you think the code submitted is wrong, please feel free to close this PR and excuse the mess.