### PR TITLE
Fix "Undefined array key" error on PHP 8.1

### DIFF
--- a/syntax/caption.php
+++ b/syntax/caption.php
@@ -106,7 +106,7 @@ class syntax_plugin_caption_caption extends DokuWiki_Syntax_Plugin {
             switch ($state) {
                 case DOKU_LEXER_ENTER :
                     // Handle case that there is a label in the opening tag
-                    list($match,$label) = explode(' ',$match);
+                    list($match,$label) = sexplode(' ',$match);
                     if (in_array($match,$this->_types)) {
                         $this->_type = $match;
                         switch ($this->_type) {

--- a/syntax/caption.php
+++ b/syntax/caption.php
@@ -106,7 +106,7 @@ class syntax_plugin_caption_caption extends DokuWiki_Syntax_Plugin {
             switch ($state) {
                 case DOKU_LEXER_ENTER :
                     // Handle case that there is a label in the opening tag
-                    list($match,$label) = sexplode(' ',$match);
+                    list($match,$label) = sexplode(' ',$match,'');
                     if (in_array($match,$this->_types)) {
                         $this->_type = $match;
                         switch ($this->_type) {

--- a/syntax/caption.php
+++ b/syntax/caption.php
@@ -106,7 +106,7 @@ class syntax_plugin_caption_caption extends DokuWiki_Syntax_Plugin {
             switch ($state) {
                 case DOKU_LEXER_ENTER :
                     // Handle case that there is a label in the opening tag
-                    list($match,$label) = sexplode(' ',$match,'');
+                    list($match,$label) = sexplode(' ',$match,2);
                     if (in_array($match,$this->_types)) {
                         $this->_type = $match;
                         switch ($this->_type) {


### PR DESCRIPTION
Replace "explode" function by "sexplode" function available on DokuWiki to avoid "Undefined array key" error on PHP 8.1 when no label is specified (e.g. ``<figure>`` tag instead of ``<figure fig_label>``).