### PR TITLE
Fix ODT rendering (PHP8 Warning)

### DIFF
--- a/syntax/reference.php
+++ b/syntax/reference.php
@@ -96,7 +96,11 @@ class syntax_plugin_caption_reference extends DokuWiki_Syntax_Plugin {
                 case DOKU_LEXER_SPECIAL :
                     $renderer->doc .= '<text:sequence-ref text:reference-format="value" text:ref-name="'.$match.'">';
                     global $caption_labels;
-                    $renderer->doc .= $caption_labels[$match];
+                    if (isset($caption_labels[$match]) && $caption_labels[$match]) {
+                        $renderer->doc .= $caption_labels[$match];
+                    } else {
+                        $renderer->doc .= '##REF:'.$match.'##';
+                    }
                     $renderer->doc .= '</text:sequence-ref>';
                     break;
             }


### PR DESCRIPTION
Check if reference exists before attempt to use on ODT rendering mode to avoid PHP8 warnings on ODT plug-in page export. This applies the same logic currently used on XHTML rendering mode, as can be seen in  https://github.com/tillbiskup/dokuwiki-caption/blob/master/syntax/reference.php#L68