### PR TITLE
Fix caption rendering, remove unused config and add PT-BR translation

### DIFF
--- a/conf/default.php
+++ b/conf/default.php
@@ -6,5 +6,4 @@
  */
 
 //$conf['fixme']    = 'FIXME';
-$conf['_basic'] = '';
 $conf['abbrev'] = '';

--- a/conf/metadata.php
+++ b/conf/metadata.php
@@ -7,6 +7,5 @@
 
 
 //$meta['fixme'] = array('string');
-$meta['_basic'] = array('fieldset');
 $meta['abbrev'] = array('onoff');
 

--- a/lang/de/settings.php
+++ b/lang/de/settings.php
@@ -7,7 +7,6 @@
 
 // keys need to match the config setting name
 // $lang['fixme'] = 'FIXME';
-$lang['_basic'] = 'And what happens if I include here some text?';
 $lang['abbrev'] = 'Abkürzungen (Abb., Tab.) statt der vollen Namen (Abbildung, Tabelle) in den Über- und Unterschriften verwenden?';
 
 

--- a/lang/en/lang.php
+++ b/lang/en/lang.php
@@ -22,7 +22,7 @@ $lang['figure'] = 'Add figure with caption';
 $lang['table'] = 'Add table with caption';
 $lang['code'] = 'Add code listing with caption';
 $lang['file'] = 'Add file listing with caption';
-$lang['reference'] = 'Reference to figure/table';
+$lang['reference'] = 'Reference to figure/table/listing';
 
 
 //Setup VIM: ex: et ts=4 :

--- a/lang/ko/settings.php
+++ b/lang/ko/settings.php
@@ -1,4 +1,3 @@
 <?php
 
-$lang['_basic'] = '일반적인 명칭 사용';
 $lang['abbrev'] = '줄임말 사용';

--- a/lang/pt-br/lang.php
+++ b/lang/pt-br/lang.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * English language file for caption plugin
+ *
+ * @author Till Biskup <till@till-biskup>
+ */
+
+// menu entry for admin plugins
+// $lang['menu'] = 'Your menu entry';
+
+// custom language strings for the plugin
+// $lang['fixme'] = 'FIXME';
+$lang['figurelong'] = 'Figura';
+$lang['figureabbrev'] = 'Fig.';
+$lang['tablelong'] = 'Tabela';
+$lang['tableabbrev'] = 'Tab.';
+$lang['codelong'] = 'Listagem';
+$lang['codeabbrev'] = 'Listagem';
+$lang['filelong'] = 'Listagem';
+$lang['fileabbrev'] = 'Listagem';
+$lang['figure'] = 'Adicionar figura com legenda';
+$lang['table'] = 'Adicionar tabela com legenda';
+$lang['code'] = 'Adicionar listagem com legenda';
+$lang['file'] = 'Adicionar listagem de arquivo com legenda';
+$lang['reference'] = 'Referenciar a figura/tabela/listagem';
+
+
+//Setup VIM: ex: et ts=4 :

--- a/lang/pt-br/settings.php
+++ b/lang/pt-br/settings.php
@@ -1,0 +1,14 @@
+<?php
+/**
+ * english language file for caption plugin
+ *
+ * @author Till Biskup <till@till-biskup>
+ */
+
+// keys need to match the config setting name
+// $lang['fixme'] = 'FIXME';
+$lang['abbrev'] = 'Usar abreviações (Fig., Tab.) em legendas ao invés de nomes completos (Figura, Tabela)?';
+
+
+
+//Setup VIM: ex: et ts=4 :

--- a/syntax/caption.php
+++ b/syntax/caption.php
@@ -107,10 +107,9 @@ class syntax_plugin_caption_caption extends DokuWiki_Syntax_Plugin {
                 case DOKU_LEXER_ENTER :
                     // Handle case that there is a label in the opening tag
                     // Fix warnings in PHP >=8.1, not relying on "sexplode" in DW Jack Jackrum
-                    $match = explode(' ',$match)[0];
                     $label = count(explode(' ',$match)) > 1 ? explode(' ',$match)[1] : null;
-                    if (in_array($match,$this->_types)) {
-                        $this->_type = $match;
+                    if (in_array(explode(' ',$match)[0],$this->_types)) {
+                        $this->_type = explode(' ',$match)[0];
                         switch ($this->_type) {
                             case "figure" :
                                 $renderer->doc .= '<figure class="plugin_caption_figure"';


### PR DESCRIPTION
Caption doesn't seems to be rendered since 2023-05-27 update. This commit also removes unused  setting from configuration and add PT-BR translation to the plugin.