### PR TITLE
Image alignment support and depreciation fix

### DIFF
--- a/script.js
+++ b/script.js
@@ -1,0 +1,61 @@
+jQuery(document).ready(function() {
+    if (JSINFO.ACT === "admin") {return;}
+    jQuery('.plugin_caption_figure').each(function(i,e) {
+        let figureElem = jQuery(this).find("img").first();
+        let figureCaptionElem = jQuery(this).find("figcaption").first();
+        
+        getImageSize(figureElem, function(width, height){
+            figureElemWidth = width;
+            if (figureElem.attr("width") !== 0 && figureElem.attr("width") !== undefined && figureElem.attr("width") !== false) {
+                figureElemWidth = figureElem.attr('width');
+            }
+            
+            let figureClassList = figureElem.attr('class').split(/\s+/);
+            jQuery(figureClassList).each(function(index){
+                switch(figureClassList[index]) {
+                    case 'medialeft':
+                    figureCaptionElem.addClass("medialeft");
+                    figureCaptionElem.css("width", figureElemWidth);
+                    break;
+                    case 'mediaright':
+                    figureCaptionElem.addClass("mediaright");
+                    figureCaptionElem.css("width", figureElemWidth);
+                    break;
+                }
+            });
+        });
+    });
+});
+
+// https://stackoverflow.com/questions/23390393/get-image-height-before-its-fully-loaded
+function getImageSize(img, callback){
+    img = jQuery(img);
+    
+    var wait = setInterval(function(){        
+        var w = img.width(),
+        h = img.height();
+        
+        if(w && h){
+            done(w, h);
+        }
+    }, 0);
+    
+    var onLoad;
+    img.on('load', onLoad = function(){
+        done(img.width(), img.height());
+    });
+    
+    
+    var isDone = false;
+    function done(){
+        if(isDone){
+            return;
+        }
+        isDone = true;
+        
+        clearInterval(wait);
+        img.off('load', onLoad);
+        
+        callback.apply(this, arguments);
+    }
+}

--- a/syntax/caption.php
+++ b/syntax/caption.php
@@ -3,17 +3,8 @@
  * DokuWiki Plugin caption (Syntax Component)
  *
  * @license GPL 2 http://www.gnu.org/licenses/gpl-2.0.html
- * @author  Till Biskup <till@till-biskup>
+ * @author  Till Biskup <till@till-biskup.de>
  */
-
-// must be run within Dokuwiki
-if (!defined('DOKU_INC')) die();
-
-if (!defined('DOKU_LF')) define('DOKU_LF', "\n");
-if (!defined('DOKU_TAB')) define('DOKU_TAB', "\t");
-if (!defined('DOKU_PLUGIN')) define('DOKU_PLUGIN',DOKU_INC.'lib/plugins/');
-
-require_once DOKU_PLUGIN.'syntax.php';
 
 class syntax_plugin_caption_caption extends DokuWiki_Syntax_Plugin {
 
@@ -430,38 +421,20 @@ class syntax_plugin_caption_caption extends DokuWiki_Syntax_Plugin {
                         $renderer->p_close();
                         switch ($this->_type) {
                             case "figure" :
-                                $renderer->doc .= '<text:p text:style-name="Illustration">';
                                 if ($this->getConf('abbrev')) {
-                                    $renderer->doc .= $this->getLang('figureabbrev');
+                                    $renderer->cdata($this->getLang('figureabbrev'));
                                 } else {
-                                    $renderer->doc .= $this->getLang('figurelong');
+                                    $renderer->cdata($this->getLang('figurelong'));
                                 }
-                                $renderer->doc .= '<text:sequence text:ref-name="';
-                                if ($this->_label) {
-                                    $renderer->doc .= $this->_label;
-                                    $this->_label = '';
-                                } else {
-                                    $renderer->doc .= 'refIllustration' . $this->_fignum;
-                                }
-                                $renderer->doc .= '" text:name="Illustration" text:formula="ooow:Illustration+1" style:num-format="1">';
-                                $renderer->doc .= ' ' . $this->_fignum . '</text:sequence>: ';
+                                $renderer->cdata(" " . $this->_fignum . ": ");
                                 break;
                             case "table" :
-                                $renderer->doc .= '<text:p text:style-name="Table">';
                                 if ($this->getConf('abbrev')) {
-                                    $renderer->doc .= $this->getLang('tableabbrev');
+                                    $renderer->cdata($this->getLang('tableabbrev'));
                                 } else {
-                                    $renderer->doc .= $this->getLang('tablelong');
+                                    $renderer->cdata($this->getLang('tablelong'));
                                 }
-                                $renderer->doc .= '<text:sequence text:ref-name="';
-                                if ($this->_label) {
-                                    $renderer->doc .= $this->_label;
-                                    $this->_label = '';
-                                } else {
-                                    $renderer->doc .= 'refTable' . $this->_tabnum;
-                                }
-                                $renderer->doc .= '" text:name="Table" text:formula="ooow:Table+1" style:num-format="1">';
-                                $renderer->doc .= ' ' . $this->_tabnum . '</text:sequence>: ';
+                                $renderer->cdata(" " . $this->_tabnum . ": ");
                                 break;
                         }
                     } else {
@@ -479,7 +452,6 @@ class syntax_plugin_caption_caption extends DokuWiki_Syntax_Plugin {
                     break;
 
                 case DOKU_LEXER_UNMATCHED :
-                    // return the dokuwiki markup within the figure tags
                     $renderer->cdata($match);
                     break;
 

--- a/syntax/reference.php
+++ b/syntax/reference.php
@@ -13,8 +13,6 @@ if (!defined('DOKU_LF')) define('DOKU_LF', "\n");
 if (!defined('DOKU_TAB')) define('DOKU_TAB', "\t");
 if (!defined('DOKU_PLUGIN')) define('DOKU_PLUGIN',DOKU_INC.'lib/plugins/');
 
-require_once DOKU_PLUGIN.'syntax.php';
-
 class syntax_plugin_caption_reference extends DokuWiki_Syntax_Plugin {
 
     /**


### PR DESCRIPTION
Workaround for https://github.com/tillbiskup/dokuwiki-caption/issues/22 and Fixes https://github.com/tillbiskup/dokuwiki-caption/issues/25.
Now caption aligns with image alignment:
<img width="696" alt="image" src="https://github.com/tillbiskup/dokuwiki-caption/assets/2974895/960fc54d-b992-4ae3-b623-9b6c7ce20c5f">
