### PR TITLE
Add image alignment support

### DIFF
--- a/script.js
+++ b/script.js
@@ -1,0 +1,60 @@
+jQuery(document).ready(function() {
+    if (JSINFO.ACT === "admin") {return;}
+    jQuery('.plugin_caption_figure').each(function(i,e) {
+        let figureElem = jQuery(this).find("img").first();
+        let figureCaptionElem = jQuery(this).find("figcaption").first();
+        
+        getImageSize(figureElem, function(width, height){
+            figureElemWidth = width;
+            if (figureElem.attr("width") !== 0 && figureElem.attr("width") !== undefined && figureElem.attr("width") !== false) {
+                figureElemWidth = figureElem.attr('width');
+            }
+            
+            let figureClassList = figureElem.attr('class').split(/\s+/);
+            jQuery(figureClassList).each(function(index){
+                switch(figureClassList[index]) {
+                    case 'medialeft':
+                    figureCaptionElem.addClass("medialeft");
+                    figureCaptionElem.css("width", figureElemWidth);
+                    break;
+                    case 'mediaright':
+                    figureCaptionElem.addClass("mediaright");
+                    figureCaptionElem.css("width", figureElemWidth);
+                    break;
+                }
+            });
+        });
+    });
+});
+
+function getImageSize(img, callback){
+    img = jQuery(img);
+    
+    var wait = setInterval(function(){        
+        var w = img.width(),
+        h = img.height();
+        
+        if(w && h){
+            done(w, h);
+        }
+    }, 0);
+    
+    var onLoad;
+    img.on('load', onLoad = function(){
+        done(img.width(), img.height());
+    });
+    
+    
+    var isDone = false;
+    function done(){
+        if(isDone){
+            return;
+        }
+        isDone = true;
+        
+        clearInterval(wait);
+        img.off('load', onLoad);
+        
+        callback.apply(this, arguments);
+    }
+}


### PR DESCRIPTION
This isn't the ideal solution (I believe the best one would be changing syntax/caption.php file and parse the image tag inside the caption tag to determine it's current alignment instead of relying on client-side scripts), but it's better than nothing.
Workaround for https://github.com/tillbiskup/dokuwiki-caption/issues/22
Now caption aligns with image alignment:
<img width="696" alt="image" src="https://github.com/tillbiskup/dokuwiki-caption/assets/2974895/960fc54d-b992-4ae3-b623-9b6c7ce20c5f">